### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <img src="logo.webp" alt="Logo">
   </a>
 
-  <h1 style="text-align:center">Journal Policy Tracker Backend</h1>
+  <h1 style="text-align:center">Journal Policy Tracker Frontend</h1>
 
 </p>
 


### PR DESCRIPTION
## Description

Changed the typo mistake i.e backend to frontend in the readme.

Fixes #64 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
