### PR TITLE
fixed header button overflow

### DIFF
--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -11,7 +11,8 @@
   padding: 20px;
   border: none;
   margin-top: 20em;
-  margin-left: 60em;
+  position: absolute;
+  left: 60%;
 }
 
 .header button:hover {


### PR DESCRIPTION
In the header section of the homepage, the button "Read and Sign the manifesto" was not responsive and overflowed in the mobile view of the website, which is now fixed with this pull request.
