### PR TITLE
Logo on clicked is redirected to home page

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -15,7 +15,7 @@ function Navigation() {
       style={{ paddingLeft: '30px', paddingRight: '30px' }}
       fixed="top"
     >
-      <Navbar.Brand href='#home'>
+      <Navbar.Brand href='/'>
         <img src={Logo} alt='' srcSet='' height={81} width={150} />
       </Navbar.Brand>
       <Navbar.Toggle aria-controls='responsive-navbar-nav' />


### PR DESCRIPTION
# Pull Request Template

## Description

On clicking the logo from any page now it is redirected to home page. Previously only "#home" was being added to URL.

Fixes #110 

## Type of change
Please delete options that are not relevant.

 []-Bug fix (non-breaking change which fixes an issue).
