### PR TITLE
Fixed Bug related to active status of navigation bar

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -13,7 +13,7 @@ function Navigation() {
       bg='light'
       variant='light'
       style={{ paddingLeft: '30px', paddingRight: '30px' }}
-      fixed="top"
+      fixed='top'
     >
       <Navbar.Brand href='#home'>
         <img src={Logo} alt='' srcSet='' height={81} width={150} />
@@ -22,22 +22,22 @@ function Navigation() {
       <Navbar.Collapse id='responsive-navbar-nav' className='justify-content-evenly'>
         <Nav>
           <LinkContainer to='/' exact>
-            <Nav.Link>Home</Nav.Link>
+            <Nav.Link active={false}>Home</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/journal' exact>
-            <Nav.Link>Journals</Nav.Link>
+            <Nav.Link active={false}>Journals</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/manifesto' exact>
-            <Nav.Link>Manifesto</Nav.Link>
+            <Nav.Link active={false}>Manifesto</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/contact' exact>
-            <Nav.Link>Contact</Nav.Link>
+            <Nav.Link active={false}>Contact</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/login' exact>
-            <Nav.Link>Login</Nav.Link>
+            <Nav.Link active={false}>Login</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/signup' exact>
-            <Nav.Link>Sign Up</Nav.Link>
+            <Nav.Link active={false}>Sign Up</Nav.Link>
           </LinkContainer>
         </Nav>
         <SearchBar />


### PR DESCRIPTION
## Description
While navigating through the navigation bar, if the user uses back button of the browser then the active status of previous page still persists. So we have two tabs/links active in the navigation bar and this might confuse the user as to which page he/she is currently using. To know more about it please refer issue #133 .

Fixes # (issue)
The problem was not with the code, but the package (react-bootstrap) we are using. I have changed the active status of all of them to false in order to solve this issue. To know more about the specific details, please refer [Reference1](https://github.com/react-bootstrap/react-router-bootstrap/issues/242) , [Reference 2](https://github.com/react-bootstrap/react-router-bootstrap/issues/243)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


## Additional Context 
https://user-images.githubusercontent.com/71634100/162747440-32c0af8d-dbb1-4cec-b529-96522eb2e8cb.mp4


## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
