### PR TITLE
Added margin top to fix hiding of paragraph

### DIFF
--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -58,7 +58,9 @@ const Contact = () => {
   return (
     <Container>
       <h1 className="mt-4">Contact Us</h1>
-      <p>Ideas? Comments? Critiques? Want to help out? Here’s how to get in contact:</p>
+      <p className='mt-p'>
+        Ideas? Comments? Critiques? Want to help out? Here’s how to get in contact:
+      </p>
       <Row className='contact-card-one'>
         <Col md={6}>
           <div className='contact-card' style={{ color: '#E74D3C' }}>

--- a/src/styles/Contact.css
+++ b/src/styles/Contact.css
@@ -21,3 +21,6 @@
   padding: 0;
   margin: 0;
 }
+.mt-p {
+  margin-top: 5em;
+}


### PR DESCRIPTION

## Description
The paragraph tag in the Contact section was being overlapped by NavBar and was not visible. Refer to issue #150 

## Fixes 
Added margin-top using custom class to avoid overlapping.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).

## Additional Context (Please include any Screenshots/gifs if relevant)
<img width="1437" alt="Screenshot 2022-04-19 at 7 53 07 PM" src="https://user-images.githubusercontent.com/76654144/164026316-d9c21bdb-33bc-484d-b8f0-d452faf5ed04.png">


## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
