### PR TITLE
Centered the "Read and Sign the Manifesto"

### DIFF
--- a/src/components/Landing/Header/Header.css
+++ b/src/components/Landing/Header/Header.css
@@ -12,8 +12,8 @@
   border-radius: 30px;
   padding: 20px;
   border: none;
-  margin-top: 20em;
-  margin-left: calc(((100% - 270px) / 3) * 2);
+  margin-top: 28em;
+  margin-left: calc(((82% - 270px) / 3) * 2);
 }
 
 .header button:hover {
@@ -57,7 +57,7 @@
   .header button {
     margin-top: 8em;
     font-size: 14px;
-    margin-left: 12em;
+    margin-left: 10em;
   }
   .header {
     height: 190px;


### PR DESCRIPTION
OLD:
![Screenshot (30)](https://user-images.githubusercontent.com/102804548/182766012-15e1f2e9-5795-431a-9587-c02736703759.png)


NEW:
![Screenshot (29)](https://user-images.githubusercontent.com/102804548/182765875-f26dca55-e4b0-4b85-ba25-7d3cc5bb4848.png)

The "Read and Sign the Manifesto" button was not centered proper which made the UI of the website bad.

I hope the new change makes the UI much more clean & better.
