### PR TITLE
fix: premise section responsiveness

### DIFF
--- a/src/components/Landing/LandingSection/styles.js
+++ b/src/components/Landing/LandingSection/styles.js
@@ -2,16 +2,16 @@ import styled from 'styled-components';
 
 export const SectionOne = styled.section`
   margin-top: 5rem;
-  margin-bottom: 5em;
+  margin-bottom: 4em;
   text-align: center;
-  display: grid;
-  justify-content: center;
+  display: grid; 
+  justify-items: center;
 `;
 
 export const CardContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  justify-content: start;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 1rem;
   padding: 1rem;
 `;
@@ -23,6 +23,7 @@ export const Card = styled.div`
   border-style: none;
   text-align: center;
   align-items: center;
+  width: 22em;
 `;
 
 export const ImageHeader = styled.img`
@@ -45,7 +46,7 @@ export const SectionTwo = styled.section`
 
 export const Div2 = styled.div`
   display: flex;
-  padding: 0.5rem 0rem;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   gap: 4rem;


### PR DESCRIPTION
## Description
Made premise section in the landing page more responsive for smaller screens.

Fixes #200 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

1. Go to homepage
2. Scroll down to Precise section and open dev tools.
3. Set dimensions for any smaller screen device.

## Additional Context (Please include any Screenshots/gifs if relevant)
### Before:
![image](https://user-images.githubusercontent.com/98693953/194720841-3e45adec-c991-487c-9a67-c3ae9f063b42.png)
### After:
![1](https://user-images.githubusercontent.com/98693953/194721138-6650bc22-7b52-4160-9fc3-ed63eafe7fd8.png)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
