### PR TITLE
fix: make third grid responsive

### DIFF
--- a/src/components/Landing/LandingSection/LandingSection.js
+++ b/src/components/Landing/LandingSection/LandingSection.js
@@ -13,6 +13,7 @@ import {
   Para1,
   SectionTwo,
   Div2,
+  Div3,
   Para,
   Image2,
   SectionOH1,
@@ -44,13 +45,13 @@ function LandingSection() {
           </Para>
           <Image2 src={landingpage.section2.img.src} alt={landingpage.section2.img.alt} />
         </Div2>
-        <Div2>
+        <Div3>
           <Image2 src={landingpage.section3.img.src} alt={landingpage.section3.img.alt} />
           <Para>
             <SectionTH2>{landingpage.section3.head}</SectionTH2>
             <Para2>{landingpage.section3.para}</Para2>
           </Para>
-        </Div2>
+        </Div3>
       </SectionTwo>
     </>
   );

--- a/src/components/Landing/LandingSection/styles.js
+++ b/src/components/Landing/LandingSection/styles.js
@@ -2,16 +2,16 @@ import styled from 'styled-components';
 
 export const SectionOne = styled.section`
   margin-top: 5rem;
-  margin-bottom: 4em;
+  margin-bottom: 5em;
   text-align: center;
-  display: grid; 
-  justify-items: center;
+  display: grid;
+  justify-content: center;
 `;
 
 export const CardContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  justify-content: start;
   gap: 1rem;
   padding: 1rem;
 `;
@@ -23,7 +23,6 @@ export const Card = styled.div`
   border-style: none;
   text-align: center;
   align-items: center;
-  width: 22em;
 `;
 
 export const ImageHeader = styled.img`
@@ -46,10 +45,28 @@ export const SectionTwo = styled.section`
 
 export const Div2 = styled.div`
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap:wrap;
+  padding: 0.5rem 0rem;
   justify-content: center;
   align-items: center;
   gap: 4rem;
+  
+  @media (max-width: 800px) {
+      gap:1rem;
+    } 
+`;
+export const Div3 = styled.div`
+  display: flex;
+  flex-wrap:wrap;
+  padding: 0.5rem 0rem;
+  justify-content: center;
+  align-items: center;
+  gap: 4rem;
+  
+  @media (max-width: 800px) {
+      flex-direction:column-reverse;
+      gap:1rem;
+    } 
 `;
 
 export const Para = styled.div`
@@ -89,4 +106,8 @@ export const Section2P = styled.p`
 export const SectionTH2 = styled.h2`
   font-size: 1.5rem;
   font-weight: 900;
+
+  @media (max-width: 800px) {
+    font-size: 1.25rem;
+    } 
 `;

--- a/src/components/Landing/LandingSection/styles.js
+++ b/src/components/Landing/LandingSection/styles.js
@@ -52,7 +52,7 @@ export const Div2 = styled.div`
   gap: 4rem;
   
   @media (max-width: 800px) {
-      gap:1rem;
+      gap:5rem;
     } 
 `;
 export const Div3 = styled.div`
@@ -65,7 +65,7 @@ export const Div3 = styled.div`
   
   @media (max-width: 800px) {
       flex-direction:column-reverse;
-      gap:1rem;
+      gap:5rem;
     } 
 `;
 


### PR DESCRIPTION

## Description

Made the Third Grid on the Homepage Responsive 

Fixes # (issue)
#201 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).


## How Has This Been Tested?

Go to homepage
Scroll down to the Precise section and open dev tools.
Set dimensions for any smaller screen device.

## Additional Context (Please include any Screenshots/gifs if relevant)

Before:
<img width="1440" alt="194605011-7d8f88f5-c4ec-464d-8721-d583a315770a" src="https://user-images.githubusercontent.com/76839614/194801914-7d8f3f52-d122-4e42-8522-a44e83c533be.png">


After:
![hacktoberfestbug1](https://user-images.githubusercontent.com/76839614/194801891-7177fc30-62ee-4341-88ab-d448daf05ce4.gif)

...

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding tests.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have signed the commit message to agree to the Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.


