### PR TITLE
fix: environment variables working

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const errorLink = onError(({ graphqlErrors, networkError }) => {
 
 const link = from([
   errorLink,
-  new HttpLink({ uri: 'http://localhost:4000/graphql', credentials: 'include' }),
+  new HttpLink({ uri: process.env.REACT_APP_PUBLIC_API_URL, credentials: 'include' }),
 ]);
 
 const client = new ApolloClient({


### PR DESCRIPTION
This pull request fixes the issue of environment variables not working. All the environment variables in a react project require "REACT_APP" in the beginning of their names for them to work.

Now for the project to work, we need to create a `.env` file in the root of the project and add a variable to it that would look something like the following:

```bash
REACT_APP_PUBLIC_API_URL=http://localhost:4000/graphql
```

